### PR TITLE
docs: expand root AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,31 +1,73 @@
 # Repository Guidelines
 
-This is a monorepo with two independent projects:
+This monorepo contains two independent projects:
 
-1. **PR Atlas** (`www/apps/dev/`) — A React web app (TanStack Start + Vite) for GitHub PR review management
-2. **jf CLI** (`jf-cli/`) — A Go CLI tool for Git worktree and stacked-commit workflows
+| Project | Path | Stack |
+|---------|------|--------|
+| **PR Atlas** (web app) | `www/apps/dev/` | React, TanStack Start + Router, Vite, Tailwind |
+| **jf CLI** | `jf-cli/` | Go (Cobra) |
 
-## Cursor Cloud specific instructions
+There is no single root `package.json`; the JavaScript workspace lives under `www/` (see below).
 
-### Services
+## Repository layout
+
+```
+/
+├── AGENTS.md          ← This file (monorepo overview)
+├── www/               ← pnpm workspace (see www/pnpm-workspace.yaml)
+│   ├── package.json   ← Workspace root; `pnpm.onlyBuiltDependencies` for esbuild / unrs-resolver
+│   └── apps/dev/      ← PR Atlas app — run app scripts from here or via `pnpm --filter dev`
+└── jf-cli/            ← Go module; see jf-cli/AGENTS.md for CLI-specific conventions
+```
+
+## Prerequisites
+
+- **Web**: [pnpm](https://pnpm.io/) 10.x (see `packageManager` in `www/package.json`).
+- **CLI**: Go toolchain for building and testing `jf-cli/`.
+
+## PR Atlas web app (`www/apps/dev`)
+
+### Install
+
+From the repo root:
+
+```bash
+cd www && pnpm install
+```
+
+### Commands
+
+Run from `www/apps/dev`, or from `www` using `pnpm --filter dev <script>` (e.g. `pnpm --filter dev dev`).
+
+| Task | Command |
+|------|---------|
+| Dev server (Vite, port 3000) | `pnpm dev` |
+| Production build | `pnpm build` |
+| Preview production build | `pnpm preview` |
+| Lint | `pnpm lint` (ESLint). Pre-existing lint warnings/errors may exist. |
+| Tests | `pnpm test` (Vitest). There are currently no `*.test` / `*.spec` files under `www/`; Vitest exits with code 1 when no tests are found. |
+| Format / check | `pnpm format` (Prettier); `pnpm check` runs Prettier write + ESLint fix |
+| Storybook | `pnpm storybook` (port 6006) |
+
+### Notes
+
+- The app uses local-only TanStack DB collections with hardcoded seed data — no database or API keys are required for core features.
+- **Build scripts**: `esbuild` and `unrs-resolver` require approved postinstall scripts. The `pnpm.onlyBuiltDependencies` field in `www/package.json` must include them; without it, `pnpm install` can skip postinstall and Vite may fail.
+- PostgreSQL / Drizzle is only used by the `/demo/drizzle` route and is not required for core PR Atlas behavior.
+
+## jf CLI (`jf-cli`)
+
+See **[jf-cli/AGENTS.md](jf-cli/AGENTS.md)** for package layout, style, and agent-oriented CLI notes.
+
+| Task | Command |
+|------|---------|
+| Build | `go build ./...` or `go build -o jf ./cmd/jf` |
+| Test | `go test ./...` |
+| Format | `go fmt ./...` |
+
+## Cursor Cloud — services
 
 | Service | Directory | Dev command | Port | Notes |
 |---------|-----------|-------------|------|-------|
-| PR Atlas web app | `www/apps/dev` | `pnpm dev` | 3000 | Uses mock/seed data; no DB or API keys required |
+| PR Atlas web app | `www/apps/dev` | `pnpm dev` | 3000 | Mock/seed data; no DB or API keys required |
 | jf CLI | `jf-cli` | `go build ./cmd/jf` | N/A | Standalone binary, no server |
-
-### Web app (`www/apps/dev`)
-
-- **Lint**: `pnpm lint` (ESLint). Pre-existing lint warnings/errors exist in the codebase.
-- **Tests**: `pnpm test` (Vitest). Currently no test files exist; `vitest run` exits with code 1 when there are no test files.
-- **Dev server**: `pnpm dev` starts Vite on port 3000. The app uses local-only TanStack DB collections with hardcoded seed data — no database or external services needed.
-- **Build scripts**: `esbuild` and `unrs-resolver` require approved build scripts. The `pnpm.onlyBuiltDependencies` field in `www/package.json` handles this. Without it, `pnpm install` skips their postinstall and Vite will fail.
-- **Storybook**: `pnpm storybook` on port 6006 (optional).
-- The PostgreSQL/Drizzle integration is only used by the `/demo/drizzle` route and is not required for the core PR Atlas features.
-
-### Go CLI (`jf-cli`)
-
-- See `jf-cli/AGENTS.md` for coding conventions and commands.
-- **Build**: `go build ./...` or `go build -o jf ./cmd/jf`
-- **Test**: `go test ./...`
-- **Format**: `go fmt ./...`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the repository root `AGENTS.md` with:

- **Repository layout** — where the pnpm workspace (`www/`) and `jf-cli/` live relative to the repo root
- **Prerequisites** — pnpm 10.x and Go
- **Install** — `cd www && pnpm install`
- **Command tables** — dev, build, preview, lint, test, format/check, Storybook for PR Atlas; build/test/fmt for jf CLI (with pointer to `jf-cli/AGENTS.md`)
- **Preserved** — Cursor Cloud services table and notes on seed data, `onlyBuiltDependencies`, Drizzle demo route, Vitest/no-test-files behavior

No code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7f0aaaa-578f-4d77-9433-d9a8a6eb7dca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7f0aaaa-578f-4d77-9433-d9a8a6eb7dca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

